### PR TITLE
Update format-pad26-avvisi.md

### DIFF
--- a/format/format-pad26-avvisi.md
+++ b/format/format-pad26-avvisi.md
@@ -15,8 +15,8 @@
 | data_inizio_bando | datetime | Data di pubblicazione dell'avviso | YYYY-MM-dd|
 | data_fine_bando | datetime | Data di scadenza dell'avviso, entro cui è possibile inviare una candidatura | YYYY-MM-dd|
 | stato| string | Stato attuale dell'avviso | |
-| totale_importo_stanziato | integer | Fondi stanziati per il finanziamento delle candidature dell'avviso | |
-| totale_importo_misura | integer | Fondi totali previsti da PNRR per la singola misura. | |
+| totale_importo_stanziato | float | Fondi stanziati per il finanziamento delle candidature dell'avviso | |
+| totale_importo_misura | float | Fondi totali previsti da PNRR per la singola misura. | |
 | soggetti_destinatari | string | Soggetti destinatari dell'avviso che si possono candidare su PA digitale 2026 | |
 
 Questi dati sono disponibili anche in formato json.


### PR DESCRIPTION
gli importi potrebbero avere decimali (ad es. questo accade nel bando delle misure M1C1-1.3.1) poi non so se la piattaforma li tronca